### PR TITLE
Fix SEPAFormatDate.formatDate()

### DIFF
--- a/src/main/java/org/java/sepaxml/format/SEPAFormatDate.java
+++ b/src/main/java/org/java/sepaxml/format/SEPAFormatDate.java
@@ -6,7 +6,7 @@ import java.util.Date;
 public class SEPAFormatDate {
 
     public static String formatDate(Date date) {
-        return new SimpleDateFormat("yyyymmddhhmmss").format(date);
+        return new SimpleDateFormat("yyyyMMddhhmmss").format(date);
     }
 
     public static String formatDateShort(Date date) {

--- a/src/test/java/org/java/sepaxml/format/SEPAFormatDateTest.java
+++ b/src/test/java/org/java/sepaxml/format/SEPAFormatDateTest.java
@@ -10,10 +10,10 @@ public class SEPAFormatDateTest {
 
     @Test
     public void formatDate() throws Exception {
-        assertEquals("20000010120000", SEPAFormatDate.formatDate(new Date(100, 5, 10)));
-        assertEquals("20150029120000", SEPAFormatDate.formatDate(new Date(115, 11, 29)));
-        assertEquals("19700002120000", SEPAFormatDate.formatDate(new Date(70, 1, 30)));
-        assertEquals("20250014120000", SEPAFormatDate.formatDate(new Date(125, 8, 14)));
+        assertEquals("20000610120000", SEPAFormatDate.formatDate(new Date(100, 5, 10)));
+        assertEquals("20151229120000", SEPAFormatDate.formatDate(new Date(115, 11, 29)));
+        assertEquals("19700302120000", SEPAFormatDate.formatDate(new Date(70, 1, 30)));
+        assertEquals("20250914120000", SEPAFormatDate.formatDate(new Date(125, 8, 14)));
     }
 
     @Test


### PR DESCRIPTION
The `formatDate` method uses the minutes instead of the months.

Thank you for the project 🙏

